### PR TITLE
Add process workflow agentic scripts

### DIFF
--- a/agentic-scripts/README.md
+++ b/agentic-scripts/README.md
@@ -9,6 +9,7 @@ This directory contains the glassBead Agentic Script Enhancement System, specifi
 - **adas-meta-agent** (`evolution`) - Advanced evolution capabilities
 - **intelligent-debugger** (`dev-tools`) - Advanced dev tools capabilities
 - **memory-manager** (`memory`) - Advanced memory capabilities
+- **process-workflows** (`workflows`) - Structured improvement frameworks (Stage-Gate, DMAIC, PDCA, A3, OODA, Build-Measure-Learn, Double Diamond, Gamified Learning)
 
 ## 🏰 Waldzell AI Integration
 
@@ -38,6 +39,9 @@ chmod +x agentic-scripts/**/*.sh
 
 # Intelligent debugging
 ./agentic-scripts/dev-tools/intelligent-debugger.sh --live
+
+# Run a process workflow
+./agentic-scripts/workflows/stage-gate.sh
 ```
 
 ## 🌐 Collective Intelligence

--- a/agentic-scripts/workflows/a3.sh
+++ b/agentic-scripts/workflows/a3.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# A3 Problem-Solving Workflow
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PHASES=("Problem" "Root Cause" "Countermeasures" "Implementation" "Follow-up")
+
+echo -e "${YELLOW}📝 A3 Problem-Solving${NC}"
+
+for PHASE in "${PHASES[@]}"; do
+  echo -e "\n${GREEN}Step: $PHASE${NC}"
+  claude -p "In the A3 problem-solving method, describe guidance for the $PHASE step." --max-turns 1 2>/dev/null || true
+  read -p "Proceed to next step? (y/n) " DECISION
+  if [[ "$DECISION" != "y" ]]; then
+    echo "A3 process ended at $PHASE"
+    exit 0
+  fi
+done
+
+echo -e "\n${YELLOW}A3 problem-solving cycle complete${NC}"

--- a/agentic-scripts/workflows/build-measure-learn.sh
+++ b/agentic-scripts/workflows/build-measure-learn.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Build-Measure-Learn Workflow (Lean Startup)
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PHASES=("Build" "Measure" "Learn")
+
+echo -e "${YELLOW}🚀 Build-Measure-Learn${NC}"
+
+while true; do
+  for PHASE in "${PHASES[@]}"; do
+    echo -e "\n${GREEN}Stage: $PHASE${NC}"
+    claude -p "In the Build-Measure-Learn loop, give concise guidance for the $PHASE stage." --max-turns 1 2>/dev/null || true
+  done
+  read -p "Iterate again? (y/n) " DECISION
+  [[ "$DECISION" == "y" ]] || break
+done
+
+echo -e "\n${YELLOW}Build-Measure-Learn loop complete${NC}"

--- a/agentic-scripts/workflows/dmaic.sh
+++ b/agentic-scripts/workflows/dmaic.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# DMAIC (Define-Measure-Analyze-Improve-Control) Workflow
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PHASES=("Define" "Measure" "Analyze" "Improve" "Control")
+
+echo -e "${YELLOW}📊 DMAIC Process${NC}"
+
+for PHASE in "${PHASES[@]}"; do
+  echo -e "\n${GREEN}Phase: $PHASE${NC}"
+  claude -p "Within DMAIC, describe goals and deliverables for the $PHASE phase." --max-turns 1 2>/dev/null || true
+  read -p "Move to next phase? (y/n) " DECISION
+  if [[ "$DECISION" != "y" ]]; then
+    echo "DMAIC cycle stopped at $PHASE phase"
+    exit 0
+  fi
+done
+
+echo -e "\n${YELLOW}DMAIC cycle complete${NC}"

--- a/agentic-scripts/workflows/double-diamond.sh
+++ b/agentic-scripts/workflows/double-diamond.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Double Diamond / Design Thinking Workflow
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PHASES=("Discover" "Define" "Develop" "Deliver")
+
+echo -e "${YELLOW}💎 Double Diamond / Design Thinking${NC}"
+
+for PHASE in "${PHASES[@]}"; do
+  echo -e "\n${GREEN}Phase: $PHASE${NC}"
+  claude -p "Explain activities and objectives for the $PHASE phase in the Double Diamond design thinking model." --max-turns 1 2>/dev/null || true
+  read -p "Proceed to next phase? (y/n) " DECISION
+  if [[ "$DECISION" != "y" ]]; then
+    echo "Process ended at $PHASE phase"
+    exit 0
+  fi
+done
+
+echo -e "\n${YELLOW}Double Diamond cycle complete${NC}"

--- a/agentic-scripts/workflows/gamified-learning.sh
+++ b/agentic-scripts/workflows/gamified-learning.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Gamified Learning Strategy Workflow
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+LEVEL=1
+
+echo -e "${YELLOW}🎮 Gamified Learning Workflow${NC}"
+
+while true; do
+  echo -e "\n${GREEN}Level $LEVEL${NC}"
+  claude -p "Suggest a challenge and reward structure for level $LEVEL in a gamified learning strategy." --max-turns 1 2>/dev/null || true
+  read -p "Level complete? (y/n) " DECISION
+  if [[ "$DECISION" != "y" ]]; then
+    echo "Gamified learning session ended at level $LEVEL"
+    break
+  fi
+  LEVEL=$((LEVEL+1))
+  read -p "Continue to next level? (y/n) " CONT
+  [[ "$CONT" == "y" ]] || break
+done
+
+echo -e "\n${YELLOW}Gamified learning session complete${NC}"

--- a/agentic-scripts/workflows/ooda-loop.sh
+++ b/agentic-scripts/workflows/ooda-loop.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# OODA Loop Workflow
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PHASES=("Observe" "Orient" "Decide" "Act")
+
+echo -e "${YELLOW}🎯 OODA Loop${NC}"
+
+while true; do
+  for PHASE in "${PHASES[@]}"; do
+    echo -e "\n${GREEN}Stage: $PHASE${NC}"
+    claude -p "Provide actionable advice for the $PHASE stage of the OODA loop." --max-turns 1 2>/dev/null || true
+  done
+  read -p "Run another OODA cycle? (y/n) " DECISION
+  [[ "$DECISION" == "y" ]] || break
+done
+
+echo -e "\n${YELLOW}OODA loop session finished${NC}"

--- a/agentic-scripts/workflows/pdca.sh
+++ b/agentic-scripts/workflows/pdca.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# PDCA (Plan-Do-Check-Act) Workflow
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PHASES=("Plan" "Do" "Check" "Act")
+
+echo -e "${YELLOW}🔁 PDCA Cycle${NC}"
+
+for PHASE in "${PHASES[@]}"; do
+  echo -e "\n${GREEN}Phase: $PHASE${NC}"
+  claude -p "For the PDCA cycle, give concise guidance for the $PHASE phase." --max-turns 1 2>/dev/null || true
+  read -p "Continue to next phase? (y/n) " DECISION
+  if [[ "$DECISION" != "y" ]]; then
+    echo "PDCA cycle halted at $PHASE phase"
+    exit 0
+  fi
+done
+
+echo -e "\n${YELLOW}PDCA cycle complete${NC}"

--- a/agentic-scripts/workflows/stage-gate.sh
+++ b/agentic-scripts/workflows/stage-gate.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Stage-Gate (Phase-Gate) Process Workflow
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PHASES=("Discovery" "Scoping" "Business Case" "Development" "Testing" "Launch")
+
+echo -e "${YELLOW}🚪 Stage-Gate Process${NC}"
+
+for PHASE in "${PHASES[@]}"; do
+  echo -e "\n${GREEN}Phase: $PHASE${NC}"
+  claude -p "In the Stage-Gate process, outline key activities and exit criteria for the $PHASE phase." --max-turns 1 2>/dev/null || true
+  read -p "Proceed past $PHASE gate? (y/n) " DECISION
+  if [[ "$DECISION" != "y" ]]; then
+    echo "Stopped at $PHASE gate"
+    exit 0
+  fi
+done
+
+echo -e "\n${YELLOW}Stage-Gate workflow complete${NC}"


### PR DESCRIPTION
## Summary
- add workflow scripts for Stage-Gate, DMAIC, PDCA, A3, OODA, Build-Measure-Learn, Double Diamond, and Gamified Learning
- document process workflows in agentic-scripts README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896fd3b39788325a8900e9e9608c9ca